### PR TITLE
Fix: Loading new data into charts puts the data into the wrong sides (fixes #83)

### DIFF
--- a/frontend/vite-project/src/components/CurrencyExchange/SnapshotHistory.tsx
+++ b/frontend/vite-project/src/components/CurrencyExchange/SnapshotHistory.tsx
@@ -92,8 +92,8 @@ export function SnapshotHistory({ snapshot }: { snapshot: CurrencyExchangeSnapsh
         }));
 
         setChartData(prev => ({
-            lineData: [...newVolumes, ...prev.lineData],
-            histogramData: [...newMarketCaps, ...prev.histogramData],
+            lineData: [...newMarketCaps, ...prev.lineData],
+            histogramData: [...newVolumes, ...prev.histogramData],
         }));
       }
     } catch (err) {


### PR DESCRIPTION
## Description

This PR fixes issue #83 where loading new data into charts puts the data into the wrong sides of the chart.

## Problem
In SnapshotHistory.tsx, when loading more historical data, the lineData and histogramData were swapped:
- lineData was receiving 
ewVolumes instead of 
ewMarketCaps
- histogramData was receiving 
ewMarketCaps instead of 
ewVolumes

## Solution
Swapped the data assignment so that:
- lineData correctly receives 
ewMarketCaps
- histogramData correctly receives 
ewVolumes

This matches the initial data load behavior where lineData contains market caps and histogramData contains volumes.

## Testing
- Verified the fix matches the initial load pattern
- No linting errors introduced