### PR TITLE
Prevent scroll reset

### DIFF
--- a/apps/my-react-router-app/app/features/exchange/components/exchange-pair-table.tsx
+++ b/apps/my-react-router-app/app/features/exchange/components/exchange-pair-table.tsx
@@ -60,7 +60,7 @@ export default function ExchangePairTable({
     nextSearchParams.set("page", String(nextState.page));
     nextSearchParams.set("perPage", String(nextState.perPage));
 
-    setSearchParams(nextSearchParams);
+    setSearchParams(nextSearchParams, { preventScrollReset: true });
   };
 
   const toggleSort = (sort: ExchangeSort) => {


### PR DESCRIPTION
## Summary
- Preserve the current viewport when updating trading pairs pagination and table controls.
- Pass `preventScrollReset: true` to `setSearchParams` in the exchange pair table so query-param updates no longer jump the page.

## Testing
- Typecheck passed locally.
- Verified the change is scoped to the trading pairs table and does not affect the global `ScrollRestoration` setup.